### PR TITLE
Fix issue to parse scale url parameter

### DIFF
--- a/lib/browserified.js
+++ b/lib/browserified.js
@@ -336,12 +336,17 @@ if (window.location.href.indexOf("?") != -1) {
       var key = value.shift();
       value = value[0];
 
-      if ((value!=undefined) && configDefault.hasOwnProperty(key)) {
-        switch (key) {
-          case "scale":
-            if (!isNaN(scale)) { window.localStorage.setItem("scale", value); }
-            return;
+      if (value == undefined) {
+        return;
+      }
 
+      if (key == "scale" && !isNaN(value)) {
+        window.localStorage.setItem("scale", value);
+        return;
+      }
+
+      if (configDefault.hasOwnProperty(key)) {
+        switch (key) {
           case "channel":
             configData.channel = value.split(",").map( function(channel) {
               return "#" + channel;

--- a/source/main.js
+++ b/source/main.js
@@ -305,12 +305,17 @@ if (window.location.href.indexOf("?") != -1) {
       var key = value.shift();
       value = value[0];
 
-      if ((value!=undefined) && configDefault.hasOwnProperty(key)) {
-        switch (key) {
-          case "scale":
-            if (!isNaN(scale)) { window.localStorage.setItem("scale", value); }
-            return;
+      if (value == undefined) {
+        return;
+      }
 
+      if (key == "scale" && !isNaN(value)) {
+        window.localStorage.setItem("scale", value);
+        return;
+      }
+
+      if (configDefault.hasOwnProperty(key)) {
+        switch (key) {
           case "channel":
             configData.channel = value.split(",").map( function(channel) {
               return "#" + channel;


### PR DESCRIPTION
This PR change the method to parse url parameters for applying scale option properly.

`scale` is a command but not configurable element, and `scale` key does not exist on `configDefault` object.
So I moved the code to check `scale` parameter before it filtered by keys of configDefault.
