### PR TITLE
`dccon_list.js`에 외부 주소를 사용할 수 있도록 지원

### DIFF
--- a/lib/browserified.js
+++ b/lib/browserified.js
@@ -766,11 +766,11 @@ if (configData.loadDcCons) {
             {
               const dccon = dcConsData[keywordData.dcconIndex];
 
-              if(dccon.url !== undefined)
+              if(dccon.url !== undefined && typeof(dccon.url) === "string" && dccon.url.startsWith('http'))
               {
                 message = message.split(`~${keyword}`).join(`<img class="dccon" src="${dccon.url}" />`);
               }
-              else if(dccon.uri !== undefined)
+              else if(dccon.uri !== undefined && typeof(dccon.uri) === "string" && dccon.uri.startsWith('http'))
               {
                 message = message.split(`~${keyword}`).join(`<img class="dccon" src="${dccon.uri}" />`);
               }

--- a/lib/browserified.js
+++ b/lib/browserified.js
@@ -738,29 +738,48 @@ if (configData.loadDcCons) {
     document.body.appendChild(dcConScript);
 
     dcConScript.onload = function() {
-      if (dcConsData.length == 0) { debugLog("디씨콘을 불러오는 데 실패했습니다."); }
+      if (dcConsData.length === 0) { debugLog("디씨콘을 불러오는 데 실패했습니다."); }
       else {
-        var keywords = [];
-        for (var index in dcConsData) {
-          for (var index2 in dcConsData[index].keywords) {
-            keywords.push(dcConsData[index].keywords[index2]);
-          }
-        }
-        keywords.sort(function(a,b) { return b.length - a.length; } );
+        /**
+         * reduce + spread operator
+         * 
+         * 나중에 다시 인덱스 검색을 줄이기 위해서 
+         * 리스트에 dcConsData에서의 인덱스를 추가함.
+         */
+        let keywordsWithIndex = dcConsData.reduce((prev, cur, idx) => {
+          const keywords = cur.keywords.map(k => {
+            const obj = {};
+            obj.dcconIndex = idx;
+            obj.keyword = k;
+            return obj;
+          });
+          return [...prev, ...keywords];
+        }, []); 
+        keywordsWithIndex.sort(function(a,b) { return b.keyword.length - a.keyword.length; } );
 
         applyDcCon = function(message, data) {
-          for (var index in keywords) {
-            var keyword = keywords[index];
-            if (message.indexOf("~" + keyword) != -1) {
-              message = message.split("~" + keyword).join(
-                '<img class="dccon" src="' +
-                configData.dcConsURI + dcConsSubURI +
-                dcConsData.find( function(element) {
-                  return element.keywords.indexOf(keyword) != -1;
-                } ).name +
-                '" />');
+
+          for (const idx in keywordsWithIndex) {
+            const keywordData = keywordsWithIndex[idx];
+            const keyword = keywordData.keyword;
+            if(message.indexOf(`~${keyword}`) !== -1)
+            {
+              const dccon = dcConsData[keywordData.dcconIndex];
+
+              if(dccon.url !== undefined)
+              {
+                message = message.split(`~${keyword}`).join(`<img class="dccon" src="${dccon.url}" />`);
+              }
+              else if(dccon.uri !== undefined)
+              {
+                message = message.split(`~${keyword}`).join(`<img class="dccon" src="${dccon.uri}" />`);
+              }
+              else {
+                message = message.split(`~${keyword}`).join(`<img class="dccon" src="${configData.dcConsURI + dcConsSubURI + dccon.name}" />`);
+              }
+
             }
-          }
+          }   
 
           return message;
         };

--- a/source/main.js
+++ b/source/main.js
@@ -700,29 +700,48 @@ if (configData.loadDcCons) {
     document.body.appendChild(dcConScript);
 
     dcConScript.onload = function() {
-      if (dcConsData.length == 0) { debugLog("디씨콘을 불러오는 데 실패했습니다."); }
+      if (dcConsData.length === 0) { debugLog("디씨콘을 불러오는 데 실패했습니다."); }
       else {
-        var keywords = [];
-        for (var index in dcConsData) {
-          for (var index2 in dcConsData[index].keywords) {
-            keywords.push(dcConsData[index].keywords[index2]);
-          }
-        }
-        keywords.sort(function(a,b) { return b.length - a.length; } );
+        /**
+         * reduce + spread operator
+         * 
+         * 나중에 다시 인덱스 검색을 줄이기 위해서 
+         * 리스트에 dcConsData에서의 인덱스를 추가함.
+         */
+        let keywordsWithIndex = dcConsData.reduce((prev, cur, idx) => {
+          const keywords = cur.keywords.map(k => {
+            const obj = {};
+            obj.dcconIndex = idx;
+            obj.keyword = k;
+            return obj;
+          });
+          return [...prev, ...keywords];
+        }, []); 
+        keywordsWithIndex.sort(function(a,b) { return b.keyword.length - a.keyword.length; } );
 
         applyDcCon = function(message, data) {
-          for (var index in keywords) {
-            var keyword = keywords[index];
-            if (message.indexOf("~" + keyword) != -1) {
-              message = message.split("~" + keyword).join(
-                '<img class="dccon" src="' +
-                configData.dcConsURI + dcConsSubURI +
-                dcConsData.find( function(element) {
-                  return element.keywords.indexOf(keyword) != -1;
-                } ).name +
-                '" />');
+
+          for (const idx in keywordsWithIndex) {
+            const keywordData = keywordsWithIndex[idx];
+            const keyword = keywordData.keyword;
+            if(message.indexOf(`~${keyword}`) !== -1)
+            {
+              const dccon = dcConsData[keywordData.dcconIndex];
+
+              if(dccon.url !== undefined && typeof(dccon.url) === "string" && dccon.url.startsWith('http'))
+              {
+                message = message.split(`~${keyword}`).join(`<img class="dccon" src="${dccon.url}" />`);
+              }
+              else if(dccon.uri !== undefined && typeof(dccon.uri) === "string" && dccon.uri.startsWith('http'))
+              {
+                message = message.split(`~${keyword}`).join(`<img class="dccon" src="${dccon.uri}" />`);
+              }
+              else {
+                message = message.split(`~${keyword}`).join(`<img class="dccon" src="${configData.dcConsURI + dcConsSubURI + dccon.name}" />`);
+              }
+
             }
-          }
+          }   
 
           return message;
         };


### PR DESCRIPTION
`dccon_list.js`에서 `url`또는 `uri`속성 값이 있고 `http`로 시작한다면
외부 주소로부터 이미지를 불러올 수 있도록 하는 기능을 추가했습니다.

디시콘 검색 로직을 일부 최적화했습니다.

일부 변경사항이 커밋되지 않아 다시 풀리퀘 날립니다.