### PR TITLE
Fix legacy badge endpoint

### DIFF
--- a/lib/browserified.js
+++ b/lib/browserified.js
@@ -556,9 +556,15 @@ loadCss();
 var badgeList = {};
 if (configData.badgeVisible) {
   var globalBadgeRequest = new window.XMLHttpRequest();
+  /*
+  * https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621
+  * 기존 트위치 배지를 받아오는 endpoint가 제거되어 배지를 불러오지 못함.
+  * 이를 해결하기 위해 현재 제공되는 API를 프록싱하여 제공하는 사설 서버 URL로 설정함.
+  * 2023. 07. 08 dhfhfk
+  */
   globalBadgeRequest.open(
     "GET",
-    "https://badges.twitch.tv/v1/badges/global/display",
+    "https://chat.dhfhfk.com/helix/chat/badges/global/display",
     true
   );
 
@@ -579,7 +585,7 @@ if (configData.badgeVisible) {
         handler(globalBadgeRequest.responseText);
 
         if (configData.badgeChannelId && Number(configData.badgeChannelId)>0) {
-          var channelBadgeUrl = "https://badges.twitch.tv/v1/badges/channels/";
+          var channelBadgeUrl = "https://chat.dhfhfk.com/helix/chat/badges/channels/";
           channelBadgeUrl += configData.badgeChannelId + "/display";
 
           var channelBadgeRequest = new window.XMLHttpRequest();

--- a/source/main.js
+++ b/source/main.js
@@ -518,9 +518,15 @@ loadCss();
 var badgeList = {};
 if (configData.badgeVisible) {
   var globalBadgeRequest = new window.XMLHttpRequest();
+  /*
+  * https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621
+  * 기존 트위치 배지를 받아오는 endpoint가 제거되어 배지를 불러오지 못함.
+  * 이를 해결하기 위해 현재 제공되는 API를 프록싱하여 제공하는 사설 서버 URL로 설정함.
+  * 2023. 07. 08 dhfhfk
+  */
   globalBadgeRequest.open(
     "GET",
-    "https://chat.dhfhfk.com/helix/chat/badges/channels/",
+    "https://chat.dhfhfk.com/helix/chat/badges/global/display",
     true
   );
 

--- a/source/main.js
+++ b/source/main.js
@@ -520,7 +520,7 @@ if (configData.badgeVisible) {
   var globalBadgeRequest = new window.XMLHttpRequest();
   globalBadgeRequest.open(
     "GET",
-    "https://badges.twitch.tv/v1/badges/global/display",
+    "https://chat.dhfhfk.com/helix/chat/badges/channels/",
     true
   );
 
@@ -541,7 +541,7 @@ if (configData.badgeVisible) {
         handler(globalBadgeRequest.responseText);
 
         if (configData.badgeChannelId && Number(configData.badgeChannelId)>0) {
-          var channelBadgeUrl = "https://badges.twitch.tv/v1/badges/channels/";
+          var channelBadgeUrl = "https://chat.dhfhfk.com/helix/chat/badges/channels/";
           channelBadgeUrl += configData.badgeChannelId + "/display";
 
           var channelBadgeRequest = new window.XMLHttpRequest();


### PR DESCRIPTION
fix #18 
기존 [BridgeBBCC v0.5.5](https://github.com/krynen/BridgeBBCC/releases/tag/v0.5.5) 이하 버전에서 글로벌 및 채널 배지를 가져오는 [https://badges.twitch.tv](https://badges.twitch.tv/) 엔드포인트가 제거되어 배지를 불러오지 못합니다.

> The legacy and unsupported badges endpoint that begins with “[https://badges.twitch.tv](https://badges.twitch.tv/)” is the resource that will be shut down. (https://discuss.dev.twitch.tv/t/legacy-badges-endpoint-shutdown-details-and-timeline-june-2023/44621)

BridgeBBCC 구동 방식을 최대한 수정하지 않기 위해 트위치에서 제공하는 [Get Global Chat Badges](https://dev.twitch.tv/docs/api/reference/#get-global-chat-badges), [Get Channel Chat Badges](https://dev.twitch.tv/docs/api/reference/#get-channel-chat-badges) API를 프록싱하여 기존 엔드포인트(https://badges.twitch.tv/) 의 응답 형식과 똑같이 제공하는 대체 프록시 서버를 구축하여 제공합니다.

- Get Global Chat Badges: https://chat.dhfhfk.com/helix/chat/badges/global/display
- Get Channel Chat Badges:  https://chat.dhfhfk.com/helix/chat/badges/channels/:channel_id/display

개인 서버인 관계로 업타임이 보장되지 않을 수 있어 config에 트위치 클라이언트 ID를 제공받아 트위치에서 제공하는 API를 호출하는 해결법도 괜찮을 것 같습니다.